### PR TITLE
BAC-7: Add User JPA entity and repository with CRUD operations

### DIFF
--- a/src/main/java/com/example/backend/domain/User.java
+++ b/src/main/java/com/example/backend/domain/User.java
@@ -1,0 +1,37 @@
+package com.example.backend.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected User() {}
+
+    public User(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public String getEmail() { return email; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+
+    public void setUsername(String username) { this.username = username; }
+    public void setEmail(String email) { this.email = email; }
+}

--- a/src/main/java/com/example/backend/repository/UserRepository.java
+++ b/src/main/java/com/example/backend/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.backend.repository;
+
+import com.example.backend.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/test/java/com/example/backend/repository/UserRepositoryTest.java
+++ b/src/test/java/com/example/backend/repository/UserRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.backend.repository;
+
+import com.example.backend.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void save_persistsUserAndAssignsId() {
+        User user = new User("alice", "alice@example.com");
+
+        User saved = userRepository.save(user);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getUsername()).isEqualTo("alice");
+        assertThat(saved.getEmail()).isEqualTo("alice@example.com");
+    }
+
+    @Test
+    void findById_returnsUserWhenExists() {
+        User saved = userRepository.save(new User("bob", "bob@example.com"));
+
+        Optional<User> found = userRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getUsername()).isEqualTo("bob");
+    }
+
+    @Test
+    void findById_returnsEmptyWhenNotFound() {
+        Optional<User> found = userRepository.findById(999999L);
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void findAll_returnsAllPersistedUsers() {
+        userRepository.save(new User("charlie", "charlie@example.com"));
+        userRepository.save(new User("diana", "diana@example.com"));
+
+        List<User> users = userRepository.findAll();
+
+        assertThat(users).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void deleteById_removesUser() {
+        User saved = userRepository.save(new User("eve", "eve@example.com"));
+
+        userRepository.deleteById(saved.getId());
+
+        assertThat(userRepository.findById(saved.getId())).isEmpty();
+    }
+
+    @Test
+    void findByEmail_returnsUserWhenExists() {
+        userRepository.save(new User("frank", "frank@example.com"));
+
+        Optional<User> found = userRepository.findByEmail("frank@example.com");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getUsername()).isEqualTo("frank");
+    }
+
+    @Test
+    void createdAt_isPopulatedByDatabase() {
+        User saved = userRepository.save(new User("grace", "grace@example.com"));
+        em.flush();
+        em.refresh(saved);
+
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
- Add User entity in com.example.backend.domain with id, username, email, created_at fields
- Add UserRepository extending JpaRepository with findByEmail/findByUsername
- Add @DataJpaTest slice tests verifying save, findById, findAll, deleteById, findByEmail, createdAt